### PR TITLE
Fix lint warnings and run goimports

### DIFF
--- a/driver/mysql/mysql.go
+++ b/driver/mysql/mysql.go
@@ -3,9 +3,10 @@ package mysql
 import (
 	"database/sql"
 	"fmt"
+	"strings"
+
 	m "github.com/Boostport/migration"
 	_ "github.com/go-sql-driver/mysql"
-	"strings"
 )
 
 type MySQL struct {
@@ -41,12 +42,8 @@ func NewMySQL(dsn string) (m.Driver, error) {
 
 // Close closes the connection to the MySQL server.
 func (driver *MySQL) Close() error {
-
-	if err := driver.db.Close(); err != nil {
-		return err
-	}
-
-	return nil
+	err := driver.db.Close()
+	return err
 }
 
 func (driver *MySQL) ensureVersionTableExists() error {
@@ -114,7 +111,7 @@ func (driver *MySQL) Versions() ([]string, error) {
 	for rows.Next() {
 		var version string
 
-		err := rows.Scan(&version)
+		err = rows.Scan(&version)
 
 		if err != nil {
 			return versions, err

--- a/driver/mysql/mysql_test.go
+++ b/driver/mysql/mysql_test.go
@@ -2,10 +2,11 @@ package mysql
 
 import (
 	"database/sql"
-	"github.com/Boostport/migration"
-	"github.com/go-sql-driver/mysql"
 	"os"
 	"testing"
+
+	"github.com/Boostport/migration"
+	"github.com/go-sql-driver/mysql"
 )
 
 func TestMySQLDriver(t *testing.T) {
@@ -98,7 +99,7 @@ func TestMySQLDriver(t *testing.T) {
 		t.Errorf("Unexpected error while running migration: %s", err)
 	}
 
-	if _, err := connection.Exec("INSERT INTO test_table2 (id) values (1)"); err != nil {
+	if _, err = connection.Exec("INSERT INTO test_table2 (id) values (1)"); err != nil {
 		if err.(*mysql.MySQLError).Number != 1146 {
 			t.Errorf("Received an error while inserting into a non-existent table, but it was not a table_undefined error: %s", err)
 		}

--- a/driver/phoenix/phoenix.go
+++ b/driver/phoenix/phoenix.go
@@ -3,9 +3,10 @@ package phoenix
 import (
 	"database/sql"
 	"fmt"
+	"strings"
+
 	_ "github.com/Boostport/avatica"
 	m "github.com/Boostport/migration"
-	"strings"
 )
 
 type Phoenix struct {
@@ -41,12 +42,8 @@ func NewPhoenix(dsn string) (m.Driver, error) {
 
 // Close closes the connection to the Apache Phoenix server.
 func (driver *Phoenix) Close() error {
-
-	if err := driver.db.Close(); err != nil {
-		return err
-	}
-
-	return nil
+	err := driver.db.Close()
+	return err
 }
 
 func (driver *Phoenix) ensureVersionTableExists() error {
@@ -113,7 +110,7 @@ func (driver *Phoenix) Versions() ([]string, error) {
 	for rows.Next() {
 		var version string
 
-		err := rows.Scan(&version)
+		err = rows.Scan(&version)
 
 		if err != nil {
 			return versions, err

--- a/driver/phoenix/phoenix_test.go
+++ b/driver/phoenix/phoenix_test.go
@@ -2,10 +2,11 @@ package phoenix
 
 import (
 	"database/sql"
-	"github.com/Boostport/avatica"
-	"github.com/Boostport/migration"
 	"os"
 	"testing"
+
+	"github.com/Boostport/avatica"
+	"github.com/Boostport/migration"
 )
 
 func TestPhoenixDriver(t *testing.T) {
@@ -95,7 +96,7 @@ func TestPhoenixDriver(t *testing.T) {
 		t.Errorf("Unexpected error while running migration: %s", err)
 	}
 
-	if _, err := connection.Exec("UPSERT INTO test_table2 (id) values (1)"); err != nil {
+	if _, err = connection.Exec("UPSERT INTO test_table2 (id) values (1)"); err != nil {
 		if err.(avatica.ResponseError).Name() != "table_undefined" {
 			t.Errorf("Received an error while inserting into a non-existent table, but it was not a table_undefined error: %s", err)
 		}

--- a/driver/postgres/postgres.go
+++ b/driver/postgres/postgres.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"database/sql"
 	"fmt"
+
 	m "github.com/Boostport/migration"
 	_ "github.com/lib/pq"
 )
@@ -40,12 +41,8 @@ func NewPostgres(dsn string) (m.Driver, error) {
 
 // Close closes the connection to the Postgres server.
 func (driver *Postgres) Close() error {
-
-	if err := driver.db.Close(); err != nil {
-		return err
-	}
-
-	return nil
+	err := driver.db.Close()
+	return err
 }
 
 func (driver *Postgres) ensureVersionTableExists() error {
@@ -76,9 +73,9 @@ func (driver *Postgres) Migrate(migration *m.PlannedMigration) error {
 		return err
 	}
 
-	if _, err := tx.Exec(content); err != nil {
+	if _, err = tx.Exec(content); err != nil {
 
-		if err := tx.Rollback(); err != nil {
+		if err = tx.Rollback(); err != nil {
 			return err
 		}
 
@@ -86,30 +83,23 @@ func (driver *Postgres) Migrate(migration *m.PlannedMigration) error {
 	}
 
 	if migration.Direction == m.Up {
-		if _, err := tx.Exec("INSERT INTO "+postgresTableName+" (version) VALUES ($1)", migration.ID); err != nil {
+		if _, err = tx.Exec("INSERT INTO "+postgresTableName+" (version) VALUES ($1)", migration.ID); err != nil {
 
-			if err := tx.Rollback(); err != nil {
-				return err
-			}
-
+			err = tx.Rollback()
 			return err
+
 		}
 	} else {
-		if _, err := tx.Exec("DELETE FROM "+postgresTableName+" WHERE version=$1", migration.ID); err != nil {
+		if _, err = tx.Exec("DELETE FROM "+postgresTableName+" WHERE version=$1", migration.ID); err != nil {
 
-			if err := tx.Rollback(); err != nil {
-				return err
-			}
-
+			err = tx.Rollback()
 			return err
+
 		}
 	}
 
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-
-	return nil
+	err = tx.Commit()
+	return err
 }
 
 // Versions lists all the applied versions.
@@ -127,7 +117,7 @@ func (driver *Postgres) Versions() ([]string, error) {
 	for rows.Next() {
 		var version string
 
-		err := rows.Scan(&version)
+		err = rows.Scan(&version)
 
 		if err != nil {
 			return versions, err

--- a/driver/postgres/postgres_test.go
+++ b/driver/postgres/postgres_test.go
@@ -2,10 +2,11 @@ package postgres
 
 import (
 	"database/sql"
-	"github.com/Boostport/migration"
-	"github.com/lib/pq"
 	"os"
 	"testing"
+
+	"github.com/Boostport/migration"
+	"github.com/lib/pq"
 )
 
 func TestPostgresDriver(t *testing.T) {
@@ -101,7 +102,7 @@ func TestPostgresDriver(t *testing.T) {
 		t.Errorf("Unexpected error while running migration: %s", err)
 	}
 
-	if _, err := connection2.Exec("INSERT INTO test_table2 (id) values (1)"); err != nil {
+	if _, err = connection2.Exec("INSERT INTO test_table2 (id) values (1)"); err != nil {
 		if err.(*pq.Error).Code.Name() != "undefined_table" {
 			t.Errorf("Received an error while inserting into a non-existent table, but it was not a undefined_table error: %s", err)
 		}

--- a/driver/sqlite/sqlite.go
+++ b/driver/sqlite/sqlite.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"database/sql"
 	"fmt"
+
 	m "github.com/Boostport/migration"
 	_ "github.com/mattn/go-sqlite3"
 )
@@ -40,12 +41,8 @@ func NewSQLite(dsn string) (m.Driver, error) {
 
 // Close closes the connection to the SQLite server.
 func (driver *SQLite) Close() error {
-
-	if err := driver.db.Close(); err != nil {
-		return err
-	}
-
-	return nil
+	err := driver.db.Close()
+	return err
 }
 
 func (driver *SQLite) ensureVersionTableExists() error {
@@ -76,9 +73,9 @@ func (driver *SQLite) Migrate(migration *m.PlannedMigration) error {
 		return err
 	}
 
-	if _, err := tx.Exec(content); err != nil {
+	if _, err = tx.Exec(content); err != nil {
 
-		if err := tx.Rollback(); err != nil {
+		if err = tx.Rollback(); err != nil {
 			return err
 		}
 
@@ -86,30 +83,23 @@ func (driver *SQLite) Migrate(migration *m.PlannedMigration) error {
 	}
 
 	if migration.Direction == m.Up {
-		if _, err := tx.Exec("INSERT INTO "+sqliteTableName+" (version) VALUES (?)", migration.ID); err != nil {
+		if _, err = tx.Exec("INSERT INTO "+sqliteTableName+" (version) VALUES (?)", migration.ID); err != nil {
 
-			if err := tx.Rollback(); err != nil {
-				return err
-			}
-
+			err = tx.Rollback()
 			return err
+
 		}
 	} else {
-		if _, err := tx.Exec("DELETE FROM "+sqliteTableName+" WHERE version=?", migration.ID); err != nil {
+		if _, err = tx.Exec("DELETE FROM "+sqliteTableName+" WHERE version=?", migration.ID); err != nil {
 
-			if err := tx.Rollback(); err != nil {
-				return err
-			}
-
+			err = tx.Rollback()
 			return err
+
 		}
 	}
 
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-
-	return nil
+	err := tx.Commit()
+	return err
 }
 
 // Versions lists all the applied versions.
@@ -127,7 +117,7 @@ func (driver *SQLite) Versions() ([]string, error) {
 	for rows.Next() {
 		var version string
 
-		err := rows.Scan(&version)
+		err = rows.Scan(&version)
 
 		if err != nil {
 			return versions, err

--- a/driver/sqlite/sqlite_test.go
+++ b/driver/sqlite/sqlite_test.go
@@ -1,9 +1,10 @@
 package sqlite
 
 import (
-	"github.com/Boostport/migration"
 	"regexp"
 	"testing"
+
+	"github.com/Boostport/migration"
 )
 
 func TestSQLiteDriver(t *testing.T) {

--- a/migration.go
+++ b/migration.go
@@ -158,8 +158,6 @@ func Migrate(driver Driver, migrations Source, direction Direction, max int) (in
 
 	for _, plannedMigration := range migrationsToApply {
 
-		var err error
-
 		err = driver.Migrate(plannedMigration)
 		if err != nil {
 
@@ -178,12 +176,7 @@ func Migrate(driver Driver, migrations Source, direction Direction, max int) (in
 	}
 
 	err = driver.Close()
-
-	if err != nil {
-		return count, err
-	}
-
-	return count, nil
+	return count, err
 }
 
 func getMigrations(migrations Source) ([]*Migration, error) {


### PR DESCRIPTION
These changes fix warnings found by [gometalinter](https://github.com/alecthomas/gometalinter), which consists mostly of variable shadowing and error value return suggestions. I also ran `goimports` on the go source. I attempted to keep the formatting/style consistent. 