### PR TITLE
Add switch to enable or disable transactions when running migrations …

### DIFF
--- a/driver/postgres/postgres_test.go
+++ b/driver/postgres/postgres_test.go
@@ -15,132 +15,137 @@ func TestPostgresDriver(t *testing.T) {
 
 	database := "migrationtest"
 
-	// prepare clean database
-	connection, err := sql.Open("postgres", "postgres://postgres:@"+postgresHost+"/?sslmode=disable")
+	for _, useTransactions := range []bool{true, false} {
 
-	if err != nil {
-		t.Fatal(err)
-	}
+		// prepare clean database
+		connection, err := sql.Open("postgres", "postgres://postgres:@"+postgresHost+"/?sslmode=disable")
 
-	_, err = connection.Exec("CREATE DATABASE " + database)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if err != nil {
-		t.Fatal(err)
-	}
+		_, err = connection.Exec("CREATE DATABASE " + database)
 
-	defer connection.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	defer func() {
-		connection.Exec("DROP DATABASE IF EXISTS " + database)
-	}()
+		connection2, err := sql.Open("postgres", "postgres://postgres:@"+postgresHost+"/"+database+"?sslmode=disable")
 
-	connection2, err := sql.Open("postgres", "postgres://postgres:@"+postgresHost+"/"+database+"?sslmode=disable")
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if err != nil {
-		t.Fatal(err)
-	}
+		driver, err := New("postgres://postgres:@"+postgresHost+"/"+database+"?sslmode=disable", useTransactions)
 
-	defer connection2.Close()
+		if err != nil {
+			t.Errorf("Unable to open connection to postgres server: %s", err)
+		}
 
-	driver, err := New("postgres://postgres:@" + postgresHost + "/" + database + "?sslmode=disable")
-
-	if err != nil {
-		t.Errorf("Unable to open connection to postgres server: %s", err)
-	}
-
-	defer driver.Close()
-
-	migrations := []*migration.PlannedMigration{
-		{
-			Migration: &migration.Migration{
-				ID: "201610041422_init",
-				Up: `CREATE TABLE test_table1 (id integer not null primary key);
+		migrations := []*migration.PlannedMigration{
+			{
+				Migration: &migration.Migration{
+					ID: "201610041422_init",
+					Up: `CREATE TABLE test_table1 (id integer not null primary key);
 
 				     CREATE TABLE test_table2 (id integer not null primary key)
 `,
+				},
+				Direction: migration.Up,
 			},
-			Direction: migration.Up,
-		},
-		{
-			Migration: &migration.Migration{
-				ID:   "201610041425_drop_unused_table",
-				Up:   "DROP TABLE test_table2",
-				Down: "CREATE TABLE test_table2(id integer not null primary key)",
+			{
+				Migration: &migration.Migration{
+					ID:   "201610041425_drop_unused_table",
+					Up:   "DROP TABLE test_table2",
+					Down: "CREATE TABLE test_table2(id integer not null primary key)",
+				},
+				Direction: migration.Up,
 			},
-			Direction: migration.Up,
-		},
-		{
-			Migration: &migration.Migration{
-				ID: "201610041422_invalid_sql",
-				Up: "CREATE TABLE test_table3 (some error",
+			{
+				Migration: &migration.Migration{
+					ID: "201610041422_invalid_sql",
+					Up: "CREATE TABLE test_table3 (some error",
+				},
+				Direction: migration.Up,
 			},
-			Direction: migration.Up,
-		},
-	}
-
-	err = driver.Migrate(migrations[0])
-
-	if err != nil {
-		t.Errorf("Unexpected error while running migration: %s", err)
-	}
-
-	_, err = connection2.Exec("INSERT INTO test_table1 (id) values (1)")
-
-	if err != nil {
-		t.Errorf("Unexpected error while testing if migration succeeded: %s", err)
-	}
-
-	_, err = connection2.Exec("INSERT INTO test_table2 (id) values (1)")
-
-	if err != nil {
-		t.Errorf("Unexpected error while testing if migration succeeded: %s", err)
-	}
-
-	err = driver.Migrate(migrations[1])
-
-	if err != nil {
-		t.Errorf("Unexpected error while running migration: %s", err)
-	}
-
-	if _, err = connection2.Exec("INSERT INTO test_table2 (id) values (1)"); err != nil {
-		if err.(*pq.Error).Code.Name() != "undefined_table" {
-			t.Errorf("Received an error while inserting into a non-existent table, but it was not a undefined_table error: %s", err)
 		}
-	} else {
-		t.Error("Expected an error while inserting into non-existent table, but did not receive any.")
-	}
 
-	err = driver.Migrate(migrations[2])
+		err = driver.Migrate(migrations[0])
 
-	if err == nil {
-		t.Error("Expected an error while executing invalid statement, but did not receive any.")
-	}
+		if err != nil {
+			t.Errorf("Unexpected error while running migration: %s", err)
+		}
 
-	versions, err := driver.Versions()
+		_, err = connection2.Exec("INSERT INTO test_table1 (id) values (1)")
 
-	if err != nil {
-		t.Errorf("Unexpected error while retriving version information: %s", err)
-	}
+		if err != nil {
+			t.Errorf("Unexpected error while testing if migration succeeded: %s", err)
+		}
 
-	if len(versions) != 2 {
-		t.Errorf("Expected %d versions to be applied, %d was actually applied.", 2, len(versions))
-	}
+		_, err = connection2.Exec("INSERT INTO test_table2 (id) values (1)")
 
-	migrations[1].Direction = migration.Down
+		if err != nil {
+			t.Errorf("Unexpected error while testing if migration succeeded: %s", err)
+		}
 
-	err = driver.Migrate(migrations[1])
+		err = driver.Migrate(migrations[1])
 
-	if err != nil {
-		t.Errorf("Unexpected error while running migration: %s", err)
-	}
+		if err != nil {
+			t.Errorf("Unexpected error while running migration: %s", err)
+		}
 
-	versions, err = driver.Versions()
+		if _, err = connection2.Exec("INSERT INTO test_table2 (id) values (1)"); err != nil {
+			if err.(*pq.Error).Code.Name() != "undefined_table" {
+				t.Errorf("Received an error while inserting into a non-existent table, but it was not a undefined_table error: %s", err)
+			}
+		} else {
+			t.Error("Expected an error while inserting into non-existent table, but did not receive any.")
+		}
 
-	if err != nil {
-		t.Errorf("Unexpected error while retriving version information: %s", err)
-	}
+		err = driver.Migrate(migrations[2])
 
-	if len(versions) != 1 {
-		t.Errorf("Expected %d versions to be applied, %d was actually applied.", 2, len(versions))
+		if err == nil {
+			t.Error("Expected an error while executing invalid statement, but did not receive any.")
+		}
+
+		versions, err := driver.Versions()
+
+		if err != nil {
+			t.Errorf("Unexpected error while retriving version information: %s", err)
+		}
+
+		if len(versions) != 2 {
+			t.Errorf("Expected %d versions to be applied, %d was actually applied.", 2, len(versions))
+		}
+
+		migrations[1].Direction = migration.Down
+
+		err = driver.Migrate(migrations[1])
+
+		if err != nil {
+			t.Errorf("Unexpected error while running migration: %s", err)
+		}
+
+		versions, err = driver.Versions()
+
+		if err != nil {
+			t.Errorf("Unexpected error while retriving version information: %s", err)
+		}
+
+		if len(versions) != 1 {
+			t.Errorf("Expected %d versions to be applied, %d was actually applied.", 2, len(versions))
+		}
+
+		driver.Close()
+
+		connection2.Close()
+
+		_, err = connection.Exec("DROP DATABASE IF EXISTS " + database)
+
+		if err != nil {
+			t.Errorf("Error dropping test database: %s", err)
+		}
+
+		connection.Close()
 	}
 }


### PR DESCRIPTION
…for drivers that supports transactions.

This is useful for using the postgres driver with CockroachDB, which
does not support multiple schema change statements in a transaction.